### PR TITLE
Added error callback to spawn in spawnServer

### DIFF
--- a/lib/processes/index.js
+++ b/lib/processes/index.js
@@ -31,9 +31,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var async, concat, debug, ensureAppPort, ensureSeleniumListening, extend, findOpenPort, http, initProcesses, spawn, spawnApplication, spawnPhantom, spawnProxy, spawnSelenium;
-
-spawn = require('child_process').spawn;
+var async, concat, debug, ensureAppPort, ensureSeleniumListening, extend, findOpenPort, http, initProcesses, spawnApplication, spawnPhantom, spawnProxy, spawnSelenium;
 
 http = require('http');
 

--- a/lib/processes/server.js
+++ b/lib/processes/server.js
@@ -31,7 +31,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var createTailQuote, debug, extend, getLogWithQuote, niceTime, omit, portscanner, procCrashedError, procTimedoutError, readFileSync, spawn, spawnServer, waitFor, _ref;
+var createTailQuote, debug, extend, getLogWithQuote, niceTime, omit, portscanner, procCrashedError, procNotFoundError, procTimedoutError, readFileSync, spawn, spawnServer, trySpawn, waitFor, _ref;
 
 spawn = require('child_process').spawn;
 
@@ -107,6 +107,11 @@ procTimedoutError = function(proc, port, timeout) {
   return new Error(message);
 };
 
+procNotFoundError = function(error, cmd) {
+  error.message = "Unable to find " + cmd + ", ensure you have the required dependencies installed";
+  return error;
+};
+
 waitFor = function(proc, port, timeout, callback) {
   var check, error, procName, startTime;
   if (proc.exitCode != null) {
@@ -135,6 +140,31 @@ waitFor = function(proc, port, timeout, callback) {
   return check();
 };
 
+trySpawn = function(cmd, args, opts, cb) {
+  var check, done, error, proc;
+  error = null;
+  done = false;
+  proc = spawn(cmd, args, opts);
+  proc.on('error', function(err) {
+    if (err.errno === 'ENOENT') {
+      return error = err;
+    }
+  });
+  check = function() {
+    if (error != null) {
+      return cb(procNotFoundError(error, cmd));
+    } else {
+      if (!done) {
+        done = true;
+        return setTimeout(check, 100);
+      } else {
+        return cb(null, proc);
+      }
+    }
+  };
+  return check();
+};
+
 spawnServer = function(logs, name, cmd, args, opts, cb) {
   var port, timeout;
   port = opts.port, timeout = opts.timeout;
@@ -142,7 +172,7 @@ spawnServer = function(logs, name, cmd, args, opts, cb) {
     timeout = 1000;
   }
   return logs.openLogFile(name, 'w+', function(error, results) {
-    var child, logHandle, logPath, spawnOpts;
+    var logHandle, logPath, spawnOpts;
     if (error != null) {
       return cb(error);
     }
@@ -153,40 +183,44 @@ spawnServer = function(logs, name, cmd, args, opts, cb) {
     if (spawnOpts.cwd == null) {
       spawnOpts.cwd = process.cwd();
     }
-    child = spawn(cmd, args, spawnOpts);
-    child.baseUrl = "http://127.0.0.1:" + port;
-    child.logPath = logPath;
-    child.logHandle = logHandle;
-    child.launchCommand = cmd;
-    child.launchArguments = args;
-    child.workingDirectory = spawnOpts.cwd;
-    child.name = name;
-    process.on('exit', function() {
-      var err;
-      try {
-        return child.kill();
-      } catch (_error) {
-        err = _error;
-        return console.error(err.stack);
-      }
-    });
-    process.on('uncaughtException', function(error) {
-      var err;
-      try {
-        child.kill();
-      } catch (_error) {
-        err = _error;
-        console.error(err.stack);
-      }
-      throw error;
-    });
-    debug('start %s on port %s', name, port);
-    return waitFor(child, port, timeout, function(error) {
-      debug('started %s', name, error);
+    return trySpawn(cmd, args, spawnOpts, function(error, child) {
       if (error != null) {
         return cb(error);
       }
-      return cb(null, child);
+      child.baseUrl = "http://127.0.0.1:" + port;
+      child.logPath = logPath;
+      child.logHandle = logHandle;
+      child.launchCommand = cmd;
+      child.launchArguments = args;
+      child.workingDirectory = spawnOpts.cwd;
+      child.name = name;
+      process.on('exit', function() {
+        var err;
+        try {
+          return child.kill();
+        } catch (_error) {
+          err = _error;
+          return console.error(err.stack);
+        }
+      });
+      process.on('uncaughtException', function(error) {
+        var err;
+        try {
+          child.kill();
+        } catch (_error) {
+          err = _error;
+          console.error(err.stack);
+        }
+        throw error;
+      });
+      debug('start %s on port %s', name, port);
+      return waitFor(child, port, timeout, function(error) {
+        debug('started %s', name, error);
+        if (error != null) {
+          return cb(error);
+        }
+        return cb(null, child);
+      });
     });
   });
 };

--- a/src/processes/index.coffee
+++ b/src/processes/index.coffee
@@ -30,7 +30,6 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###
 
-{spawn} = require 'child_process'
 http = require 'http'
 
 async = require 'async'

--- a/src/processes/server.coffee
+++ b/src/processes/server.coffee
@@ -146,6 +146,13 @@ spawnServer = (logs, name, cmd, args, opts, cb) ->
     spawnOpts.cwd ?= process.cwd()
 
     child = spawn cmd, args, spawnOpts
+    
+    child.on 'error', (err) ->
+      if err.errno is 'ENOENT'
+        console.error "Unable to find #{cmd}, ensure you have the required dependencies installed"
+
+      throw err
+      
     child.baseUrl = "http://127.0.0.1:#{port}"
     child.logPath = logPath
     child.logHandle = logHandle

--- a/src/processes/server.coffee
+++ b/src/processes/server.coffee
@@ -108,6 +108,10 @@ procTimedoutError = (proc, port, timeout) ->
   message += "\n#{proc.error.trim()}" if proc.error?.length > 0
   new Error message
 
+procNotFoundError = (error, cmd) ->
+  error.message = "Unable to find #{cmd}, ensure you have the required dependencies installed"
+  error
+      
 waitFor = (proc, port, timeout, callback) ->
   if proc.exitCode?
     error = procCrashedError(proc)
@@ -132,6 +136,27 @@ waitFor = (proc, port, timeout, callback) ->
 
   check()
 
+trySpawn = (cmd, args, opts, cb) ->
+  error = null
+  done = no
+
+  proc = spawn cmd, args, opts
+  proc.on 'error', (err) ->
+    if err.errno is 'ENOENT'
+      error = err
+    
+  check = ->
+    if error?
+      cb(procNotFoundError error, cmd)
+    else
+      if !done
+        done = yes
+        setTimeout check, 100
+      else
+        cb null, proc
+        
+  check()
+    
 spawnServer = (logs, name, cmd, args, opts, cb) ->
   {port, timeout} = opts
   timeout ?= 1000
@@ -145,37 +170,32 @@ spawnServer = (logs, name, cmd, args, opts, cb) ->
     }, omit(opts, 'port', 'timeout')
     spawnOpts.cwd ?= process.cwd()
 
-    child = spawn cmd, args, spawnOpts
-    
-    child.on 'error', (err) ->
-      if err.errno is 'ENOENT'
-        console.error "Unable to find #{cmd}, ensure you have the required dependencies installed"
-
-      throw err
-      
-    child.baseUrl = "http://127.0.0.1:#{port}"
-    child.logPath = logPath
-    child.logHandle = logHandle
-    child.launchCommand = cmd
-    child.launchArguments = args
-    child.workingDirectory = spawnOpts.cwd
-    child.name = name
-
-    process.on 'exit', ->
-      try child.kill()
-      catch err
-        console.error err.stack
-
-    process.on 'uncaughtException', (error) ->
-      try child.kill()
-      catch err
-        console.error err.stack
-      throw error
-
-    debug 'start %s on port %s', name, port
-    waitFor child, port, timeout, (error) ->
-      debug 'started %s', name, error
+    trySpawn cmd, args, spawnOpts, (error, child) ->
       return cb(error) if error?
-      cb null, child
+        
+      child.baseUrl = "http://127.0.0.1:#{port}"
+      child.logPath = logPath
+      child.logHandle = logHandle
+      child.launchCommand = cmd
+      child.launchArguments = args
+      child.workingDirectory = spawnOpts.cwd
+      child.name = name
+
+      process.on 'exit', ->
+        try child.kill()
+        catch err
+          console.error err.stack
+
+      process.on 'uncaughtException', (error) ->
+        try child.kill()
+        catch err
+          console.error err.stack
+        throw error
+
+      debug 'start %s on port %s', name, port
+      waitFor child, port, timeout, (error) ->
+        debug 'started %s', name, error
+        return cb(error) if error?
+        cb null, child
 
 module.exports = { spawnServer }


### PR DESCRIPTION
Hey guys, 

I got this error recently when running some tests:
```
Error: spawn ENOENT
    at errnoException (child_process.js:1001:11)
    at Process.ChildProcess._handle.onexit (child_process.js:792:34)
```
It took me a while to realize I didn't have `java` installed in my new dev machine. I thought I'd be cool to catch the `spawn` errors and give more details when a `no such file or directory` error is thrown. 

(I also removed an unnecessary `require`)