### PR TITLE
Have phantomJS use TLSv1 to open HTTPS connections

### DIFF
--- a/lib/processes/phantom/index.js
+++ b/lib/processes/phantom/index.js
@@ -48,7 +48,7 @@ spawnPhantom = function(config, callback) {
       return callback(error);
     }
     cmd = config.phantomjs.command;
-    args = ["--webdriver=" + port, '--webdriver-loglevel=DEBUG'];
+    args = ["--webdriver=" + port, '--webdriver-loglevel=DEBUG', '--ssl-protocol=tlsv1'];
     opts = {
       port: port,
       timeout: config.phantomjs.timeout

--- a/src/processes/phantom/index.coffee
+++ b/src/processes/phantom/index.coffee
@@ -43,6 +43,7 @@ spawnPhantom = (config, callback) ->
     args = [
       "--webdriver=#{port}"
       '--webdriver-loglevel=DEBUG'
+      '--ssl-protocol=tlsv1'
     ]
     opts = {port, timeout: config.phantomjs.timeout}
     spawnServer logs, 'phantomjs', cmd, args, opts, (error, phantom) ->


### PR DESCRIPTION
http://stackoverflow.com/questions/12021578/phantomjs-failing-to-open-https-site


>Note that as of 2014-10-16, PhantomJS defaults to using SSLv3 to open HTTPS connections. With the POODLE vulnerability recently announced, many servers are disabling SSLv3 support.

>To get around that, you should be able to run PhantomJS with:

>phantomjs --ssl-protocol=tlsv1
