### PR TITLE
Allow configuration of webdriver connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ mocha:
   timeout: 20000
   # Same, just for `slow`.
   slow: 2000
+webdriver:
+  requestOptions:
+    # connect timeout for all webdriver proxy connections
+    connectTimeout: 2000
+    # read timeout for all webdriver proxy connections
+    timeout: 60000
 ```
 
 ## Testium Command-Line Tool

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,6 +43,9 @@ getDefaults = function() {
     desiredCapabilities: {},
     logDirectory: './test/log',
     screenshotDirectory: './test/log/failed_screenshots',
+    webdriver: {
+      requestOptions: {}
+    },
     app: {
       port: process.env.PORT || 0,
       timeout: 30000,

--- a/lib/testium.js
+++ b/lib/testium.js
@@ -104,11 +104,11 @@ getBrowser = function(options, done) {
       }
       selenium = results.selenium, proxy = results.proxy, application = results.application;
       createDriver = function() {
-        var desiredCapabilities, driverUrl;
+        var desiredCapabilities, driverUrl, webdriver;
         driverUrl = selenium.driverUrl;
-        desiredCapabilities = config.desiredCapabilities;
-        debug('WebDriver(%j)', driverUrl, desiredCapabilities);
-        return new WebDriver(driverUrl, desiredCapabilities);
+        desiredCapabilities = config.desiredCapabilities, webdriver = config.webdriver;
+        debug('WebDriver(%j)', driverUrl, desiredCapabilities, webdriver.requestOptions);
+        return new WebDriver(driverUrl, desiredCapabilities, webdriver.requestOptions);
       };
       createBrowser = function() {
         var browser, driver, usedCachedDriver;

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -53,6 +53,13 @@ getDefaults = ->
   # Directory to store automated screenshosts, e.g. on failing tests
   screenshotDirectory: './test/log/failed_screenshots'
 
+  # Options for web driver connections
+  # can specify timeout and connectTimeout here, defaults are
+  # connectTimeout = 2000
+  # timeout = 60000
+  webdriver:
+    requestOptions: {}
+
   app:
     # A port of 0 means "auto-select available port"
     port: process.env.PORT || 0

--- a/src/testium.coffee
+++ b/src/testium.coffee
@@ -84,9 +84,9 @@ getBrowser = (options, done) ->
 
     createDriver = ->
       {driverUrl} = selenium
-      {desiredCapabilities} = config
-      debug 'WebDriver(%j)', driverUrl, desiredCapabilities
-      new WebDriver driverUrl, desiredCapabilities
+      {desiredCapabilities, webdriver} = config
+      debug 'WebDriver(%j)', driverUrl, desiredCapabilities, webdriver.requestOptions
+      new WebDriver driverUrl, desiredCapabilities, webdriver.requestOptions
 
     createBrowser = ->
       usedCachedDriver = reuseSession && cachedDriver?


### PR DESCRIPTION
Get the odd

Error: Request connection timed out after 2000ms to: http://127.0.0.1:46767/wd/hub/session/f923ed90-9ce6-11e4-880b-8bcbc24367c8/url
    at Object.callback (/myapp/testium/node_modules/webdriver-http-sync/lib/request.js:57:15)
during integration tests.

Adding this to give ability to work around the problem.
