### PR TITLE
fix example of .testiumrc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ Then, you can specify additional configuration, like so!
 
 ```
 ; .testiumrc
-launch = true ; defaults to false, `npm start`s the app
+; defaults to false, `npm start`s the app
+launch = true
 
 [mocha]
-timeout = 10000 ; defaults to 20 seconds
-slow = 2500 ; defaults to 2 seconds
+; defaults to 20 seconds
+timeout = 10000
+; defaults to 2 seconds
+slow = 2500
 ```
 
 Run your tests with mocha: `mocha test/integration`


### PR DESCRIPTION
![2015-01-20_16-03-17](https://cloud.githubusercontent.com/assets/19714/5813248/e3d16366-a0bd-11e4-8f0c-8f540e9f5130.jpg)

Currenlty, the example of `.testiumrc` in README is invalid.

```
; .testiumrc
launch = true ; defaults to false, `npm start`s the app

[mocha]
timeout = 10000 ; defaults to 20 seconds
slow = 2500 ; defaults to 2 seconds
```

This pull request move comments to above each configs.

```
; defaults to false, `npm start`s the app
launch = true

[mocha]
; defaults to 20 seconds
timeout = 10000
; defaults to 2 seconds
slow = 2500
```
(https://github.com/azu/testium-seed/blob/gh-pages/.testiumrc work fine.)

[isaacs/ini](https://github.com/isaacs/ini "isaacs/ini") bug? I don't know about that...

