### PR TITLE
Save testium as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ describe 'browse', ->
 
 ## Getting Started
 
-Install Testium by running `npm install --save testium`.
+Install Testium by running `npm install --save-dev testium`.
 
 Then, you can specify additional configuration, like so!
 


### PR DESCRIPTION
I presume that since testium is a dev/test scope tool that it'd be more appropriate as a devDependency? Close if I'm wrong! :D