### PR TITLE
remove duplicate chromedriver check

### DIFF
--- a/lib/processes/selenium/index.js
+++ b/lib/processes/selenium/index.js
@@ -117,17 +117,9 @@ spawnSelenium = function(config, callback) {
   chromeDriverPath = (_base1 = config.selenium).chromedriver != null ? _base1.chromedriver : _base1.chromedriver = DEFAULT_CHROME_PATH;
   return async.auto({
     port: findOpenPort,
-    chromedriver: function(done) {
-      if (config.browser !== 'chrome') {
-        return done();
-      }
-      return fs.stat(chromeDriverPath, done);
+    binaries: function(done) {
+      return ensureBinaries(config.browser, jarPath, chromeDriverPath, done);
     },
-    binaries: [
-      'chromedriver', function(done) {
-        return ensureBinaries(config.browser, jarPath, chromeDriverPath, done);
-      }
-    ],
     selenium: [
       'port', 'binaries', function(done, _arg) {
         var args, options, port;

--- a/src/processes/selenium/index.coffee
+++ b/src/processes/selenium/index.coffee
@@ -130,13 +130,8 @@ spawnSelenium = (config, callback) ->
   async.auto {
     port: findOpenPort
 
-    chromedriver: (done) ->
-      return done() if config.browser != 'chrome'
-      fs.stat chromeDriverPath, done
-
-    binaries: [ 'chromedriver', (done) ->
+    binaries: (done) ->
       ensureBinaries config.browser, jarPath, chromeDriverPath, done
-    ]
 
     selenium: [ 'port', 'binaries', (done, {port}) ->
       args = [


### PR DESCRIPTION
There were two checks for a local chromedriver. The first was not presenting the fancy error. Removing it allows the second check to do so. It will now look something like:

```
Preparing chrome...

/home/smassa/source/testium/lib/cli/console.js:112
      throw error;
            ^
Could not find required files for running selenium.
       - message: ENOENT, stat '/home/smassa/source/testium/bin/chromedriver'

You can provide your own version of selenium via ~/.testiumrc:

\```
[selenium]
jar = /path/to/selenium.jar
; For running tests in chrome:
chromedriver = /path/to/chromedriver
\```

testium can also download these files for you,
just execute the following before running your test suite:

$ ./node_modules/.bin/testium --download-selenium

testium will download selenium and chromedriver into this directory:
/home/smassa/source/testium/bin
Error: ENOENT, stat '/home/smassa/source/testium/bin/chromedriver'
```

(ignore the faux-escaped triple-`)

---

Addresses: https://github.com/groupon-testium/testium/issues/133