### PR TITLE
add selenium.debug config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ selenium:
   # Path to chromedriver.
   # `null` means "use testium built-in", see `jar` above.
   chromedriver: null
+  # Log debug info to selenium.log.
+  debug: true
 repl:
   # Module for the testium repl
   # If you want to use coffee-script in the repl, use:

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,7 +59,8 @@ getDefaults = function() {
       timeout: 90000,
       serverUrl: null,
       jar: null,
-      chromedriver: null
+      chromedriver: null,
+      debug: true
     },
     repl: {
       module: 'repl'

--- a/lib/processes/selenium/index.js
+++ b/lib/processes/selenium/index.js
@@ -78,7 +78,7 @@ createSeleniumArguments = function(chromeDriverPath) {
   var chromeArgs, firefoxProfilePath;
   chromeArgs = ['--disable-application-cache', '--media-cache-size=1', '--disk-cache-size=1', '--disk-cache-dir=/dev/null', '--disable-cache', '--disable-desktop-notifications'].join(' ');
   firefoxProfilePath = path.join(__dirname, './firefox_profile.js');
-  return ["-Dwebdriver.chrome.driver=" + chromeDriverPath, "-Dwebdriver.chrome.args=\"" + chromeArgs + "\"", '-firefoxProfileTemplate', firefoxProfilePath, '-ensureCleanSession', '-debug'];
+  return ["-Dwebdriver.chrome.driver=" + chromeDriverPath, "-Dwebdriver.chrome.args=\"" + chromeArgs + "\"", '-firefoxProfileTemplate', firefoxProfilePath, '-ensureCleanSession'];
 };
 
 ensureBinaries = function(browser, jarPath, chromeDriverPath, done) {
@@ -125,6 +125,9 @@ spawnSelenium = function(config, callback) {
         var args, options, port;
         port = _arg.port;
         args = ['-Xmx256m', '-jar', jarPath, '-port', "" + port].concat(createSeleniumArguments(chromeDriverPath));
+        if (config.selenium.debug) {
+          args.push('-debug');
+        }
         options = {
           port: port,
           timeout: config.selenium.timeout

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -88,6 +88,8 @@ getDefaults = ->
     # Path to chromedriver.
     # `null` means "use testium built-in", see `jar` above.
     chromedriver: null
+    # Log debug info to selenium.log.
+    debug: true
   repl:
     # Module for the testium repl
     # If you want to use coffee-script in the repl, use:

--- a/src/processes/selenium/index.coffee
+++ b/src/processes/selenium/index.coffee
@@ -78,7 +78,6 @@ createSeleniumArguments = (chromeDriverPath) ->
     "-Dwebdriver.chrome.args=\"#{chromeArgs}\""
     '-firefoxProfileTemplate', firefoxProfilePath
     '-ensureCleanSession'
-    '-debug'
   ]
 
 ensureBinaries = (browser, jarPath, chromeDriverPath, done) ->
@@ -139,6 +138,8 @@ spawnSelenium = (config, callback) ->
         '-jar', jarPath
         '-port', "#{port}"
       ].concat createSeleniumArguments(chromeDriverPath)
+      if config.selenium.debug
+        args.push '-debug'
       options = { port, timeout: config.selenium.timeout }
       spawnServer logs, 'selenium', 'java', args, options, done
     ]


### PR DESCRIPTION
Creates a new config option `selenium.debug` and defaults it to true. This doesn't change existing behavior, but allows users to turn off the verbose debug log messages that end up in selenium.log.