### PR TITLE
Support for io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
     - 0.10
+    - 0.12
+    - iojs

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "read-package-json": "^1.2.7",
     "selenium-download": "^2.0.0",
     "semver": "^4.1.0",
-    "webdriver-http-sync": "git://github.com/groupon-testium/webdriver-http-sync#switch-sync"
+    "webdriver-http-sync": "^1.1.0"
   },
   "devDependencies": {
     "coffee-script": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "read-package-json": "^1.2.7",
     "selenium-download": "^2.0.0",
     "semver": "^4.1.0",
-    "webdriver-http-sync": "^1.0.0"
+    "webdriver-http-sync": "git://github.com/groupon-testium/webdriver-http-sync#switch-sync"
   },
   "devDependencies": {
     "coffee-script": "1.9.1",

--- a/test/integration/screenshot.test.coffee
+++ b/test/integration/screenshot.test.coffee
@@ -6,6 +6,8 @@ getIndexScreenshot = (browser) ->
   browser.assert.httpStatus 200
   browser.getScreenshot()
 
+hasImgDiff = try require 'img-diff'
+
 describe 'screenshots', ->
   before injectBrowser()
 
@@ -16,30 +18,36 @@ describe 'screenshots', ->
     it 'captures the page', ->
       assert.truthy @indexScreenshot.length > 0
 
-    it 'can be scoped to a selector', ->
-      formScreenshot = @browser.getScreenshot('#the-form')
-      assert.truthy 'selector screenshot is smaller than the page', formScreenshot.length < @indexScreenshot.length
+    if hasImgDiff
+      it 'can be scoped to a selector', ->
+        formScreenshot = @browser.getScreenshot('#the-form')
+        assert.truthy 'selector screenshot is smaller than the page', formScreenshot.length < @indexScreenshot.length
+    else
+      xit 'skipping scoped screenshots, img-diff not installed'
 
-  describe 'comparing', ->
-    before ->
-      @indexScreenshot ?= getIndexScreenshot(@browser)
+  if hasImgDiff?
+    describe 'comparing', ->
+      before ->
+        @indexScreenshot ?= getIndexScreenshot(@browser)
 
-    it 'to itself succeeds', ->
-      @browser.assert.imagesMatch(@indexScreenshot, @indexScreenshot)
+      it 'to itself succeeds', ->
+        @browser.assert.imagesMatch(@indexScreenshot, @indexScreenshot)
 
-    it 'to something else fails', ->
-      @browser.navigateTo '/other-page.html'
-      @browser.assert.httpStatus 200
-      otherScreenshot = @browser.getScreenshot()
+      it 'to something else fails', ->
+        @browser.navigateTo '/other-page.html'
+        @browser.assert.httpStatus 200
+        otherScreenshot = @browser.getScreenshot()
 
-      error = assert.throws =>
-        @browser.assert.imagesMatch(@indexScreenshot, otherScreenshot)
-      expectedError = /^Images are .+ different! Tolerance was 0\.$/
-      assert.match expectedError, error.message
+        error = assert.throws =>
+          @browser.assert.imagesMatch(@indexScreenshot, otherScreenshot)
+        expectedError = /^Images are .+ different! Tolerance was 0\.$/
+        assert.match expectedError, error.message
 
-    it 'allows tolerance', ->
-      @browser.navigateTo '/index-diff.html'
-      @browser.assert.httpStatus 200
-      diffScreenshot = @browser.getScreenshot()
-      @browser.assert.imagesMatch(@indexScreenshot, diffScreenshot, 60.00)
+      it 'allows tolerance', ->
+        @browser.navigateTo '/index-diff.html'
+        @browser.assert.httpStatus 200
+        diffScreenshot = @browser.getScreenshot()
+        @browser.assert.imagesMatch(@indexScreenshot, diffScreenshot, 60.00)
+  else
+    xit 'skipping screenshot comparison, img-diff not installed'
 

--- a/test/integration/unicode.test.coffee
+++ b/test/integration/unicode.test.coffee
@@ -12,5 +12,5 @@ describe 'unicode support', ->
     element = @browser.getElement '#blank-input'
     element.type multibyteText
     result = element.get('value')
-    assert.equal result, multibyteText
+    assert.equal multibyteText, result
 


### PR DESCRIPTION
Verifying that https://github.com/groupon-testium/webdriver-http-sync/pull/26 does not break testium.