### PR TITLE
deprecate img diff

### DIFF
--- a/API.md
+++ b/API.md
@@ -349,12 +349,7 @@ Returns screenshot as a base64 encoded PNG.
 
 ```coffee
 browser.navigateTo '/products'
-screenshot1 = browser.getScreenshot()
-
-browser.navigateTo '/products-rewrite'
-screenshot2 = browser.getScreenshot()
-
-browser.assert.imagesMatch(screenshot1, screenshot2)
+screenshot = browser.getScreenshot()
 ```
 
 ### browser.click(cssSelector)
@@ -973,7 +968,9 @@ about the test when the assertion fails.
 browser.assert.imgLoaded '.logo'
 ```
 
-### browser.assert.imagesMatch(image1, image2, tolerance=0)
+### ~~browser.assert.imagesMatch(image1, image2, tolerance=0)~~
+
+**Deprecated**
 
 Asserts that the provided images
 are equal within the given `tolerance`.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ system-level libraries.
 
 **optional**
 
-- **libpng** (for image diffing)
+- ~~**libpng**~~ **Deprecated** (for image diffing)
 <br>[Ubuntu] `sudo apt-get install libpng-dev`
 <br>[OS X] `brew install libpng`
+
 
 ## Configuration
 
@@ -336,7 +337,7 @@ Method | Description
 `browser.assert.elementDoesntExist(selector)` | Throws exceptions if selector exists.
 `browser.assert.httpStatus(statusCode)` | Throws exceptions if current status code is not equal to the provided statusCode.
 `browser.assert.imgLoaded(selector)` | Throws exceptions if selector doesn't match a single `<img>` element that has both loaded and been decoded successfully. Allows an optional extra _initial_ docstring argument, for semantic documentation about the test when the assertion fails.
-`browser.assert.imagesMatch(image1, image2, tolerance=0)` | Throws exceptions if the images don't match within the given tolerance. Warning: this method is experimental and slow. You can use `@slow(4000)` in tests to notify mocha of this.
+~~`browser.assert.imagesMatch(image1, image2, tolerance=0)`~~ | **Deprecated** Throws exceptions if the images don't match within the given tolerance. Warning: this method is experimental and slow. You can use `@slow(4000)` in tests to notify mocha of this.
 
 ### Element
 

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -100,7 +100,7 @@ ElementMixin = {
     return this.driver.getElements(selector);
   },
   waitForElement: function(selector, timeout) {
-    deprecate('waitForElement', 'waitForElementVisible');
+    console.warn('DEPRECATED: waitForElement; use waitForElementVisible instead.');
     hasType('getElements(selector) - requires (String) selector', String, selector);
     return this._waitForElement(selector, isVisiblePredicate, isVisibleFailure, timeout);
   },

--- a/lib/img_diff.js
+++ b/lib/img_diff.js
@@ -31,15 +31,26 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var errorMessage, imgDiff;
+var _imgDiff, error, errorMessage, imgDiff;
 
 imgDiff = null;
 
 errorMessage = "img-diff failed to install on your system and cannot be used.\nmake sure you have libpng installed.\nUbuntu: sudo apt-get install libpng-dev\nOS X:   brew install libpng";
 
 try {
-  imgDiff = require('img-diff');
+  _imgDiff = require('img-diff');
+  imgDiff = {
+    imagesMatch: function() {
+      console.warn('DEPRECATED: img-diff#imagesMatch');
+      return _imgDiff.imagesMatch.apply(_imgDiff, arguments);
+    },
+    crop: function() {
+      console.warn('DEPRECATED: img-diff#crop');
+      return _imgDiff.crop.apply(_imgDiff, arguments);
+    }
+  };
 } catch (_error) {
+  error = _error;
   imgDiff = {
     imagesMatch: function() {
       throw new Error(errorMessage);

--- a/src/browser/element.coffee
+++ b/src/browser/element.coffee
@@ -83,7 +83,7 @@ ElementMixin =
     @driver.getElements(selector)
 
   waitForElement: (selector, timeout) ->
-    deprecate 'waitForElement', 'waitForElementVisible'
+    console.warn 'DEPRECATED: waitForElement; use waitForElementVisible instead.'
     hasType 'getElements(selector) - requires (String) selector', String, selector
     @_waitForElement(selector, isVisiblePredicate, isVisibleFailure, timeout)
 

--- a/src/img_diff.coffee
+++ b/src/img_diff.coffee
@@ -42,8 +42,17 @@ OS X:   brew install libpng
 """
 
 try
-  imgDiff = require 'img-diff'
-catch
+  _imgDiff = require 'img-diff'
+
+  imgDiff =
+    imagesMatch: ->
+      console.warn 'DEPRECATED: img-diff#imagesMatch'
+      _imgDiff.imagesMatch.apply(_imgDiff, arguments)
+    crop: ->
+      console.warn 'DEPRECATED: img-diff#crop'
+      _imgDiff.crop.apply(_imgDiff, arguments)
+
+catch error
   imgDiff =
     imagesMatch: ->
       throw new Error errorMessage


### PR DESCRIPTION
Deprecates `img-diff`.

---

Addresses: https://github.com/groupon-testium/testium/issues/149