### PR TITLE
Add a configurable launchEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ Below are the options and their defaults:
 # It's also where testium will look for a `package.json` file
 # to figure out how to start the app.
 root: process.cwd()
-# Automatically launch the app with NODE_ENV=test.
+# Automatically launch the app with the default NODE_ENV=test.
 # Set this to true if you want testium to handle this for you
 # when you call `getBrowser`.
 launch: false
+launchEnv: 'test'
 
 # The browser to use, possible values:
 # phantomjs | chrome | firefox | internet explorer

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ root: process.cwd()
 # Set this to true if you want testium to handle this for you
 # when you call `getBrowser`.
 launch: false
+# Customize the NODE_ENV of the service being started. Example: 'integration' or 'ci'
 launchEnv: 'test'
 
 # The browser to use, possible values:

--- a/lib/config.js
+++ b/lib/config.js
@@ -39,6 +39,7 @@ getDefaults = function() {
   return {
     root: process.cwd(),
     launch: false,
+    launchEnv: 'test',
     browser: 'phantomjs',
     desiredCapabilities: {},
     logDirectory: './test/log',

--- a/lib/processes/application/index.js
+++ b/lib/processes/application/index.js
@@ -74,9 +74,9 @@ isTrulyTrue = function(value) {
 };
 
 spawnApplication = function(config, callback) {
-  var launch, logs, ref1, timeout;
-  launch = config.launch, (ref1 = config.app, timeout = ref1.timeout);
-  launch = isTrulyTrue(launch);
+  var launch, logs, timeout;
+  timeout = config.app.timeout;
+  launch = isTrulyTrue(config.launch);
   if (!launch) {
     return isAvailable(config.app.port, function(error, available) {
       if (!available) {
@@ -110,7 +110,7 @@ spawnApplication = function(config, callback) {
         cmd = args.shift();
         debug('Launching application', cmd, args);
         env = defaults({
-          NODE_ENV: 'test',
+          NODE_ENV: config.launchEnv || 'test',
           PORT: port,
           PATH: "./node_modules/.bin:" + process.env.PATH
         }, process.env);

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -38,10 +38,11 @@ getDefaults = ->
   # It's also where testium will look for a `package.json` file
   # to figure out how to start the app.
   root: process.cwd()
-  # Automatically launch the app with NODE_ENV=test.
+  # Automatically launch the app with the default NODE_ENV=test.
   # Set this to true if you want testium to handle this for you
   # when you call `getBrowser`.
   launch: false
+  launchEnv: 'test'
 
   # The browser to use, possible values:
   # phantomjs | chrome | firefox | internet explorer

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -42,6 +42,7 @@ getDefaults = ->
   # Set this to true if you want testium to handle this for you
   # when you call `getBrowser`.
   launch: false
+  # Customize the NODE_ENV of the service being started. Example: 'integration' or 'ci'
   launchEnv: 'test'
 
   # The browser to use, possible values:

--- a/src/processes/application/index.coffee
+++ b/src/processes/application/index.coffee
@@ -62,8 +62,8 @@ isTrulyTrue = (value) ->
   value == true || value == '1' || value == 'true'
 
 spawnApplication = (config, callback) ->
-  {launch, app: {timeout}} = config
-  launch = isTrulyTrue launch
+  {app: {timeout}} = config
+  launch = isTrulyTrue config.launch
 
   unless launch
     return isAvailable config.app.port, (error, available) ->
@@ -91,7 +91,7 @@ spawnApplication = (config, callback) ->
       debug 'Launching application', cmd, args
 
       env = defaults {
-        NODE_ENV: 'test'
+        NODE_ENV: config.launchEnv || 'test'
         PORT: port
         PATH: "./node_modules/.bin:#{process.env.PATH}"
       }, process.env


### PR DESCRIPTION
I'm currently working on a project that needs to be able to start up the service under test in either `test` or `ci` modes (local vs docker). This PR exposes a `launchEnv` field allowing for a `package.json` like the following:

```
"scripts": {
    "test-integration": "testium_launchEnv=$NODE_ENV mocha test/integration",
    ...
}
```

This implementation will fallback to `test` mode even if `testium_launchEnv` is blank.