### PR TITLE
make looking for an app optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ setup:
 	npm install
 
 .PHONY: test
-test: test-unit test-screenshot test-missing-selenium test-start-timeout test-integration
+test: test-unit test-screenshot test-missing-selenium test-start-timeout test-no-app test-integration
 
 test-integration: build
 	@echo "# Integration Tests #"
@@ -27,6 +27,12 @@ test-start-timeout: build
 test-missing-selenium: build
 	@echo "# Missing Selenium Tests #"
 	@./node_modules/.bin/mocha test/missing_selenium.test.coffee
+	@echo ""
+	@echo ""
+
+test-no-app: build
+	@echo "# No App Tests #"
+	@./node_modules/.bin/mocha test/no_app.test.coffee
 	@echo ""
 	@echo ""
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ logDirectory: './test/log'
 # Directory to store automated screenshosts, e.g. on failing tests
 screenshotDirectory: './test/log/failed_screenshots'
 
+# set app to `null` if you don't want testium to make sure an app is running
 app:
   # A port of 0 means "auto-select available port"
   port: process.env.PORT || 0
@@ -199,7 +200,8 @@ and mixes the methods of that browser
 into the global scope.
 
 It respects all configuration options,
-so if you enabled `launch`, it will also launch your app.
+so if you enabled `launch`,
+it will also launch your app.
 
 You can use it like so!
 

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -45,19 +45,13 @@ Assertions = require('../assert');
 patchCapabilities = require('./capabilities');
 
 Browser = (function() {
-  function Browser(driver, targetUrl, commandUrl) {
-    var invocation;
+  function Browser(driver, arg) {
+    var invocation, keepCookies, ref1, skipPriming;
     this.driver = driver;
-    this.targetUrl = targetUrl;
-    this.commandUrl = commandUrl;
+    ref1 = arg != null ? arg : {}, this.appUrl = ref1.appUrl, this.targetUrl = ref1.targetUrl, this.commandUrl = ref1.commandUrl, skipPriming = ref1.skipPriming, keepCookies = ref1.keepCookies;
     invocation = 'new Browser(driver, targetUrl, commandUrl)';
     hasType(invocation + " - requires (Object) driver", Object, this.driver);
     this.assert = new Assertions(this.driver, this);
-  }
-
-  Browser.prototype.init = function(arg) {
-    var keepCookies, ref1, skipPriming;
-    ref1 = arg != null ? arg : {}, skipPriming = ref1.skipPriming, keepCookies = ref1.keepCookies;
     if (skipPriming) {
       debug('Skipping priming load');
     } else {
@@ -70,11 +64,11 @@ Browser = (function() {
       debug('Clearing cookies for clean state');
       this.clearCookies();
     }
-    return this.setPageSize({
+    this.setPageSize({
       height: 768,
       width: 1024
     });
-  };
+  }
 
   Browser.prototype.close = function(callback) {
     var error;

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -45,17 +45,13 @@ Assertions = require('../assert');
 patchCapabilities = require('./capabilities');
 
 Browser = (function() {
-  function Browser(driver, appUrl, proxyUrl, commandUrl) {
+  function Browser(driver, targetUrl, commandUrl) {
     var invocation;
     this.driver = driver;
-    this.appUrl = appUrl;
-    this.proxyUrl = proxyUrl;
+    this.targetUrl = targetUrl;
     this.commandUrl = commandUrl;
-    invocation = 'new Browser(driver, appUrl, proxyUrl, commandUrl)';
+    invocation = 'new Browser(driver, targetUrl, commandUrl)';
     hasType(invocation + " - requires (Object) driver", Object, this.driver);
-    hasType(invocation + " - requires (String) appUrl", String, this.appUrl);
-    hasType(invocation + " - requires (String) proxyUrl", String, this.proxyUrl);
-    hasType(invocation + " - requires (String) commandUrl", String, this.commandUrl);
     this.assert = new Assertions(this.driver, this);
   }
 

--- a/lib/browser/navigation.js
+++ b/lib/browser/navigation.js
@@ -47,7 +47,7 @@ makeUrlRegExp = require('./makeUrlRegExp');
 
 NavigationMixin = {
   navigateTo: function(url, options) {
-    var currentUrl, hasProtocol, query, sep;
+    var currentUrl, hasNoProtocol, hasProtocol, query, sep;
     if (options == null) {
       options = {};
     }
@@ -61,11 +61,14 @@ NavigationMixin = {
     options = defaults({
       url: url
     }, omit(options, 'query'));
-    hasProtocol = /^[^:\/?#]+:\/\//;
-    if (!hasProtocol.test(url)) {
-      url = "" + this.proxyUrl + url;
+    if ((this.targetUrl != null) && (this.commandUrl != null)) {
+      hasProtocol = /^[^:\/?#]+:\/\//;
+      hasNoProtocol = !(hasProtocol.test(url));
+      if (hasNoProtocol) {
+        url = "" + this.targetUrl + url;
+      }
+      this.driver.http.post(this.commandUrl + "/new-page", options);
     }
-    this.driver.http.post(this.commandUrl + "/new-page", options);
     currentUrl = this.driver.getUrl();
     if (currentUrl === url) {
       this.driver.refresh();

--- a/lib/cli/console.js
+++ b/lib/cli/console.js
@@ -106,7 +106,9 @@ module.exports = function() {
   replModule = _resolveFilename(config.repl.module, pretendModule, false);
   prepareRequireExtensions(pretendModule, replModule);
   Repl = require(replModule);
-  return getBrowser(function(error, browser) {
+  return getBrowser({
+    useApp: false
+  }, function(error, browser) {
     var closeBrowser, startRepl;
     if (error != null) {
       throw error;

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,7 +31,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var getDefaults, rc;
+var config, getDefaults, rc;
 
 rc = require('rc');
 
@@ -77,4 +77,10 @@ getDefaults = function() {
   };
 };
 
-module.exports = rc('testium', getDefaults());
+config = rc('testium', getDefaults());
+
+if (config.app === 'null') {
+  config.app = null;
+}
+
+module.exports = config;

--- a/lib/mocha/index.js
+++ b/lib/mocha/index.js
@@ -102,14 +102,14 @@ injectBrowser = function(options) {
     options = {};
   }
   return function(done) {
-    var initialTimeout, reuseSession, suite;
+    var initialTimeout, ref, reuseSession, suite;
     if (this._runnable.title === DEFAULT_TITLE) {
       this._runnable.title = BETTER_TITLE;
     }
     debug('Overriding mocha timeouts', config.mocha);
     suite = this._runnable.parent;
     deepMochaTimeouts(suite);
-    initialTimeout = +config.app.timeout;
+    initialTimeout = +((ref = config.app) != null ? ref.timeout : void 0) || 0;
     initialTimeout += +config.mocha.timeout;
     this.timeout(initialTimeout);
     reuseSession = options.reuseSession != null ? options.reuseSession : options.reuseSession = true;

--- a/lib/processes/application/index.js
+++ b/lib/processes/application/index.js
@@ -75,6 +75,9 @@ isTrulyTrue = function(value) {
 
 spawnApplication = function(config, callback) {
   var launch, logs, timeout;
+  if (!config.app) {
+    return callback();
+  }
   timeout = config.app.timeout;
   launch = isTrulyTrue(config.launch);
   if (!launch) {

--- a/lib/processes/application/index.js
+++ b/lib/processes/application/index.js
@@ -47,7 +47,7 @@ ref = require('../port'), findOpenPort = ref.findOpenPort, isAvailable = ref.isA
 
 initLogs = require('../../logs');
 
-NO_LAUNCH_COMMAND_ERROR = 'Not launch command found, please add scripts.start to package.json';
+NO_LAUNCH_COMMAND_ERROR = 'No launch command found: please add scripts.start to package.json';
 
 getLaunchCommand = function(config, callback) {
   var pkgJsonPath;

--- a/lib/processes/index.js
+++ b/lib/processes/index.js
@@ -54,7 +54,8 @@ spawnSelenium = require('./selenium');
 spawnApplication = require('./application');
 
 ensureAppPort = function(config, done) {
-  if (config.app.port === 0) {
+  var ref;
+  if (((ref = config.app) != null ? ref.port : void 0) === 0) {
     return findOpenPort(function(err, port) {
       if (err != null) {
         return done(err);
@@ -108,17 +109,29 @@ initProcesses = function() {
   cached = null;
   return {
     ensureRunning: function(config, callback) {
+      var appTasks, tasks;
       if (cached != null) {
         debug('Returning cached processes');
         return process.nextTick(function() {
           return callback(cached.error, cached.results);
         });
       }
-      debug('Launching processes');
-      return async.auto({
+      appTasks = {
         ensureAppPort: function(done) {
           return ensureAppPort(config, done);
         },
+        proxy: [
+          'ensureAppPort', function(done) {
+            return spawnProxy(config, done);
+          }
+        ],
+        application: [
+          'ensureAppPort', function(done) {
+            return spawnApplication(config, done);
+          }
+        ]
+      };
+      tasks = {
         selenium: function(done) {
           if (config.desiredCapabilities.browserName === 'phantomjs') {
             return spawnPhantom(config, done);
@@ -132,18 +145,13 @@ initProcesses = function() {
             selenium = arg.selenium;
             return ensureSeleniumListening(selenium.driverUrl, done);
           }
-        ],
-        proxy: [
-          'ensureAppPort', function(done) {
-            return spawnProxy(config, done);
-          }
-        ],
-        application: [
-          'ensureAppPort', function(done) {
-            return spawnApplication(config, done);
-          }
         ]
-      }, function(error, results) {
+      };
+      if (config.app !== null) {
+        extend(tasks, appTasks);
+      }
+      debug('Launching processes');
+      return async.auto(tasks, function(error, results) {
         cached = {
           error: error,
           results: results

--- a/lib/processes/proxy/index.js
+++ b/lib/processes/proxy/index.js
@@ -40,8 +40,8 @@ findOpenPort = require('../port').findOpenPort;
 initLogs = require('../../logs');
 
 spawnProxy = function(config, callback) {
-  var appPort, args, logs, nodejs, port, proxyModule;
-  appPort = config.app.port;
+  var appPort, args, logs, nodejs, port, proxyModule, ref;
+  appPort = (ref = config.app) != null ? ref.port : void 0;
   logs = initLogs(config);
   port = 4445;
   nodejs = process.execPath;

--- a/lib/testium.js
+++ b/lib/testium.js
@@ -87,13 +87,14 @@ ensureDesiredCapabilities = function(config) {
 };
 
 getBrowser = function(options, done) {
-  var keepCookies, ref1, ref2, reuseSession;
+  var keepCookies, ref1, ref2, ref3, reuseSession, useApp;
   if (typeof options === 'function') {
     done = options;
     options = {};
   }
   reuseSession = (ref1 = options.reuseSession) != null ? ref1 : true;
   keepCookies = (ref2 = options.keepCookies) != null ? ref2 : false;
+  useApp = (ref3 = options.useApp) != null ? ref3 : config.app != null;
   assert.hasType('getBrowser requires a callback, please check the docs for breaking changes', Function, done);
   ensureDesiredCapabilities(config);
   return processes.ensureRunning(config, (function(_this) {
@@ -118,14 +119,16 @@ getBrowser = function(options, done) {
         }
       };
       createBrowser = function() {
-        var browser, driver, usedCachedDriver;
+        var browser, driver, skipPriming, usedCachedDriver;
         usedCachedDriver = reuseSession && (cachedDriver != null);
         driver = reuseSession ? cachedDriver != null ? cachedDriver : cachedDriver = createDriver() : createDriver();
-        browser = new Browser(driver, application.baseUrl, proxy.baseUrl, proxy.commandUrl);
+        skipPriming = usedCachedDriver || !useApp;
+        browser = new Browser(driver, proxy != null ? proxy.baseUrl : void 0, proxy != null ? proxy.commandUrl : void 0);
         browser.init({
-          skipPriming: usedCachedDriver,
+          skipPriming: skipPriming,
           keepCookies: keepCookies
         });
+        browser.appUrl = application.baseUrl;
         applyMixins(browser, config.mixins.browser);
         applyMixins(browser.assert, config.mixins.assert);
         return browser;

--- a/lib/testium.js
+++ b/lib/testium.js
@@ -123,12 +123,13 @@ getBrowser = function(options, done) {
         usedCachedDriver = reuseSession && (cachedDriver != null);
         driver = reuseSession ? cachedDriver != null ? cachedDriver : cachedDriver = createDriver() : createDriver();
         skipPriming = usedCachedDriver || !useApp;
-        browser = new Browser(driver, proxy != null ? proxy.baseUrl : void 0, proxy != null ? proxy.commandUrl : void 0);
-        browser.init({
+        browser = new Browser(driver, {
+          appUrl: application != null ? application.baseUrl : void 0,
+          targetUrl: proxy != null ? proxy.baseUrl : void 0,
+          commandUrl: proxy != null ? proxy.commandUrl : void 0,
           skipPriming: skipPriming,
           keepCookies: keepCookies
         });
-        browser.appUrl = application.baseUrl;
         applyMixins(browser, config.mixins.browser);
         applyMixins(browser.assert, config.mixins.assert);
         return browser;

--- a/src/browser/index.coffee
+++ b/src/browser/index.coffee
@@ -38,12 +38,9 @@ Assertions = require '../assert'
 patchCapabilities = require './capabilities'
 
 class Browser
-  constructor: (@driver, @appUrl, @proxyUrl, @commandUrl) ->
-    invocation = 'new Browser(driver, appUrl, proxyUrl, commandUrl)'
+  constructor: (@driver, @targetUrl, @commandUrl) ->
+    invocation = 'new Browser(driver, targetUrl, commandUrl)'
     hasType "#{invocation} - requires (Object) driver", Object, @driver
-    hasType "#{invocation} - requires (String) appUrl", String, @appUrl
-    hasType "#{invocation} - requires (String) proxyUrl", String, @proxyUrl
-    hasType "#{invocation} - requires (String) commandUrl", String, @commandUrl
     @assert = new Assertions @driver, this
 
   init: ({skipPriming, keepCookies} = {}) ->

--- a/src/browser/index.coffee
+++ b/src/browser/index.coffee
@@ -38,12 +38,11 @@ Assertions = require '../assert'
 patchCapabilities = require './capabilities'
 
 class Browser
-  constructor: (@driver, @targetUrl, @commandUrl) ->
+  constructor: (@driver, {@appUrl, @targetUrl, @commandUrl, skipPriming, keepCookies}={}) ->
     invocation = 'new Browser(driver, targetUrl, commandUrl)'
     hasType "#{invocation} - requires (Object) driver", Object, @driver
     @assert = new Assertions @driver, this
 
-  init: ({skipPriming, keepCookies} = {}) ->
     if skipPriming
       debug 'Skipping priming load'
     else

--- a/src/browser/navigation.coffee
+++ b/src/browser/navigation.coffee
@@ -52,11 +52,13 @@ NavigationMixin =
 
     options = defaults {url}, omit(options, 'query')
 
-    hasProtocol = /^[^:\/?#]+:\/\//
-    unless hasProtocol.test url
-      url = "#{@proxyUrl}#{url}"
+    if @targetUrl? && @commandUrl?
+      hasProtocol = /^[^:\/?#]+:\/\//
+      hasNoProtocol = !(hasProtocol.test url)
+      if hasNoProtocol
+        url = "#{@targetUrl}#{url}"
 
-    @driver.http.post "#{@commandUrl}/new-page", options
+      @driver.http.post "#{@commandUrl}/new-page", options
 
     # WebDriver does nothing if currentUrl is the same as targetUrl
     currentUrl = @driver.getUrl()

--- a/src/cli/console.coffee
+++ b/src/cli/console.coffee
@@ -100,7 +100,7 @@ module.exports = ->
 
   Repl = require replModule
 
-  getBrowser (error, browser) ->
+  getBrowser {useApp: false}, (error, browser) ->
     throw error if error?
 
     closeBrowser = ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -122,4 +122,10 @@ getDefaults = ->
     # Same, just for `slow`.
     slow: 2000
 
-module.exports = rc 'testium', getDefaults()
+config = rc 'testium', getDefaults()
+
+# config values from environment variables
+# are always strings
+config.app = null if config.app == 'null'
+
+module.exports = config

--- a/src/mocha/index.coffee
+++ b/src/mocha/index.coffee
@@ -83,7 +83,7 @@ injectBrowser = (options = {}) -> (done) ->
   suite = @_runnable.parent
   deepMochaTimeouts suite
 
-  initialTimeout = +config.app.timeout
+  initialTimeout = +config.app?.timeout || 0
   initialTimeout += +config.mocha.timeout
   @timeout initialTimeout
 

--- a/src/processes/application/index.coffee
+++ b/src/processes/application/index.coffee
@@ -62,6 +62,8 @@ isTrulyTrue = (value) ->
   value == true || value == '1' || value == 'true'
 
 spawnApplication = (config, callback) ->
+  return callback() unless config.app
+
   {app: {timeout}} = config
   launch = isTrulyTrue config.launch
 

--- a/src/processes/application/index.coffee
+++ b/src/processes/application/index.coffee
@@ -40,7 +40,7 @@ debug = require('debug')('testium:processes:application')
 initLogs = require '../../logs'
 
 NO_LAUNCH_COMMAND_ERROR =
-  'Not launch command found, please add scripts.start to package.json'
+  'No launch command found: please add scripts.start to package.json'
 
 getLaunchCommand = (config, callback) ->
   if config.app.command

--- a/src/processes/proxy/index.coffee
+++ b/src/processes/proxy/index.coffee
@@ -35,7 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 initLogs = require '../../logs'
 
 spawnProxy = (config, callback) ->
-  appPort = config.app.port
+  appPort = config.app?.port
 
   logs = initLogs config
 

--- a/src/testium.coffee
+++ b/src/testium.coffee
@@ -107,10 +107,13 @@ getBrowser = (options, done) ->
 
       skipPriming = usedCachedDriver || !useApp
 
-      # TODO: why do we need a separate init here?
-      browser = new Browser driver, proxy?.baseUrl, proxy?.commandUrl
-      browser.init { skipPriming, keepCookies }
-      browser.appUrl = application.baseUrl
+      browser = new Browser driver, {
+        appUrl: application?.baseUrl
+        targetUrl: proxy?.baseUrl
+        commandUrl: proxy?.commandUrl
+        skipPriming
+        keepCookies
+      }
 
       applyMixins browser, config.mixins.browser
       applyMixins browser.assert, config.mixins.assert

--- a/src/testium.coffee
+++ b/src/testium.coffee
@@ -71,6 +71,7 @@ getBrowser = (options, done) ->
 
   reuseSession = options.reuseSession ? true
   keepCookies = options.keepCookies ? false
+  useApp = options.useApp ? config.app?
 
   assert.hasType '''
     getBrowser requires a callback, please check the docs for breaking changes
@@ -104,8 +105,12 @@ getBrowser = (options, done) ->
         else
           createDriver()
 
-      browser = new Browser driver, application.baseUrl, proxy.baseUrl, proxy.commandUrl
-      browser.init { skipPriming: usedCachedDriver, keepCookies }
+      skipPriming = usedCachedDriver || !useApp
+
+      # TODO: why do we need a separate init here?
+      browser = new Browser driver, proxy?.baseUrl, proxy?.commandUrl
+      browser.init { skipPriming, keepCookies }
+      browser.appUrl = application.baseUrl
 
       applyMixins browser, config.mixins.browser
       applyMixins browser.assert, config.mixins.assert

--- a/test/integration/non_browser.test.coffee
+++ b/test/integration/non_browser.test.coffee
@@ -7,6 +7,8 @@ describe 'Non-browser test', ->
   before injectBrowser()
 
   it 'can make a request without using the browser', (done) ->
-    http.get "#{@browser.appUrl}/echo", (response) ->
+    url = "#{@browser.appUrl}/echo"
+    http.get(url, (response) ->
       assert.equal 200, response.statusCode
       done()
+    ).on 'error', done

--- a/test/no_app.test.coffee
+++ b/test/no_app.test.coffee
@@ -1,0 +1,30 @@
+{execFile} = require 'child_process'
+
+assert = require 'assertive'
+rimraf = require 'rimraf'
+{extend} = require 'lodash'
+
+LOG_DIRECTORY = "#{__dirname}/no_app_log"
+TEST_FILE = 'test/no_app_test.test.coffee'
+
+ENV_OVERRIDES = {
+  testium_app: null
+}
+
+describe 'App not Required', ->
+  before "rm -rf #{LOG_DIRECTORY}", (done) ->
+    rimraf LOG_DIRECTORY, done
+
+  it 'run the no_app test', (done) ->
+    @timeout 10000
+
+    mocha = execFile './node_modules/.bin/mocha', [ TEST_FILE ], {
+      env: extend(ENV_OVERRIDES, process.env)
+    }, (err, @stdout, @stderr) =>
+      try
+        assert.equal 'mocha exit code', 0, mocha.exitCode
+        done()
+      catch exitCodeError
+        console.error @stderr
+        done exitCodeError
+

--- a/test/no_app_test.test.coffee
+++ b/test/no_app_test.test.coffee
@@ -1,0 +1,9 @@
+injectBrowser = require '../mocha'
+assert = require 'assertive'
+
+describe 'without an app', ->
+  before injectBrowser()
+
+  it 'can hit the internet', ->
+    @browser.navigateTo 'http://google.com'
+

--- a/test/unit/browser/index.test.coffee
+++ b/test/unit/browser/index.test.coffee
@@ -2,6 +2,11 @@ Browser = require '../../../lib/browser'
 assert = require 'assertive'
 
 class FakeWebDriver
+  navigateTo: ->
+  getUrl: ->
+  getCurrentWindowHandle: ->
+  clearCookies: ->
+  setPageSize: ->
 
 describe 'API', ->
   describe 'construction', ->
@@ -11,14 +16,14 @@ describe 'API', ->
 
     it 'fails if driver is undefined', ->
       assert.throws ->
-        new Browser undefined, targetUrl, commandUrl
+        new Browser undefined, {targetUrl, commandUrl}
 
     it 'fails if driver is not an object', ->
       assert.throws ->
-        new Browser 'Not a driver', targetUrl, commandUrl
+        new Browser 'Not a driver', {targetUrl, commandUrl}
 
     it 'succeeds if all conditions are met', ->
-      new Browser driver, targetUrl, commandUrl
+      new Browser driver
 
   describe '#close', ->
     it 'fails if callback is not a Function', ->

--- a/test/unit/browser/index.test.coffee
+++ b/test/unit/browser/index.test.coffee
@@ -6,47 +6,19 @@ class FakeWebDriver
 describe 'API', ->
   describe 'construction', ->
     driver = new FakeWebDriver()
-    appUrl = 'http://127.0.0.1:3000'
-    proxyUrl = 'http://127.0.0.1:1000'
+    targetUrl = 'http://127.0.0.1:1000'
     commandUrl = 'http://127.0.0.1:2000'
 
     it 'fails if driver is undefined', ->
       assert.throws ->
-        new Browser undefined, appUrl, proxyUrl, commandUrl
+        new Browser undefined, targetUrl, commandUrl
 
     it 'fails if driver is not an object', ->
       assert.throws ->
-        new Browser 'Not a driver', appUrl, proxyUrl, commandUrl
-
-    it 'fails if appUrl is not a String', ->
-      assert.throws ->
-        new Browser driver, 1000, proxyUrl, commandUrl
-
-    it 'fails if appUrl is undefined', ->
-      assert.throws ->
-        new Browser driver, undefined, proxyUrl, commandUrl
-
-    it 'fails if proxyUrl is not a String', ->
-      assert.throws ->
-        new Browser driver, appUrl, 1000, commandUrl
-
-    it 'fails if proxyUrl is undefined', ->
-      assert.throws ->
-        new Browser driver, appUrl, undefined, commandUrl
-
-    it 'fails if commandUrl is undefined', ->
-      assert.throws ->
-        new Browser driver, appUrl, proxyUrl, undefined
-
-    it 'fails if commandUrl is not a String', ->
-      err = assert.throws ->
-        new Browser driver, appUrl, proxyUrl, 999
-      assert.include '''
-        new Browser(driver, appUrl, proxyUrl, commandUrl) - requires (String) commandUrl
-      ''', err.message
+        new Browser 'Not a driver', targetUrl, commandUrl
 
     it 'succeeds if all conditions are met', ->
-      new Browser driver, appUrl, proxyUrl, commandUrl
+      new Browser driver, targetUrl, commandUrl
 
   describe '#close', ->
     it 'fails if callback is not a Function', ->


### PR DESCRIPTION
Using testium without a local app to hit is currently problematic. Using the local CLI is also a problem because of this.

This PR makes the app optional. However, there are a lot of conditionals added to the codebase to support this. Some refactoring is probably in order.

---

Addresses: https://github.com/groupon-testium/testium/issues/150