### PR TITLE
deprecate getScreenshot(cssSelector)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Method | Description
 `browser.getPageSource()` | Returns the current page's html source.
 `browser.getPageSize()` | Returns the current window's size.
 `browser.setPageSize({height, width})` | Sets the current window's size.
+~~`browser.getScreenshot(selector)`~~ | **Deprecated** Returns screenshot as a base64 encoded PNG bounded by the element at `cssSelector`.
 `browser.getScreenshot()` | Returns screenshot as a base64 encoded PNG.
 `browser.click(cssSelector)` | Calls Click on the Element found by the given `cssSelector`.
 `browser.type(cssSelector, value)` | Sends `value` to the input Element found by the given `cssSelector`.

--- a/src/browser/page.coffee
+++ b/src/browser/page.coffee
@@ -56,6 +56,7 @@ module.exports =
   getScreenshot: (selector) ->
     if selector?
       hasType 'getScreenshot(selector) - requires (String) selector or nothing', String, selector
+      console.warn 'DEPRECATED: getScreenshot(selector); use getScreenshot() instead.'
       screenshot = @driver.getScreenshot()
       @_cropScreenshotBySelector(screenshot, selector)
     else


### PR DESCRIPTION
When we remove `img-diff`, we won't be able to get a screenshot bounded by a `cssSelector` anymore. This deprecates that functionality before we remove it.